### PR TITLE
Fix hassfest manifest documentation

### DIFF
--- a/custom_components/electric_kiwi/manifest.json
+++ b/custom_components/electric_kiwi/manifest.json
@@ -9,6 +9,7 @@
     "application_credentials"
   ],
   "documentation": "https://github.com/mikey0000/ha-electric-kiwi",
+  "issue_tracker": "https://github.com/mikey0000/ha-electric-kiwi/issues",
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "requirements": [

--- a/custom_components/electric_kiwi/manifest.json
+++ b/custom_components/electric_kiwi/manifest.json
@@ -8,7 +8,7 @@
   "dependencies": [
     "application_credentials"
   ],
-  "documentation": "https://www.home-assistant.io/integrations/electric_kiwi",
+  "documentation": "https://github.com/mikey0000/ha-electric-kiwi",
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "requirements": [


### PR DESCRIPTION
There were a few errors in the [hassfest actions ](https://github.com/mikey0000/ha-electric-kiwi/actions/runs/13154631996/job/36708869339).
However I was not sure how to fix the [HACS Brands requirement](https://hacs.xyz/docs/publish/include/#check-brands) especially because it's already filled by the `core_integrations/electric_kiwi` and I didn't wanted to introduce a conflict adding stuffs into the `custom_integrations/electric_kiwi`.